### PR TITLE
Fix date parsing bug for EU deployments (DD/MM/YYYY)

### DIFF
--- a/src/utils/dates.py
+++ b/src/utils/dates.py
@@ -13,12 +13,14 @@ def parse_date(date_str: str) -> date:
     """
     Parse a date string into a datetime.date.
 
-    Intended supported formats:
+    Supported formats:
       - MM/DD/YYYY  (common in US)
       - DD/MM/YYYY  (common in EU)
 
-    NOTE: This implementation currently contains an intentional bug:
-    it assumes MM/DD/YYYY even when input is DD/MM/YYYY.
+    The function auto-detects the format based on the values:
+      - If the first number > 12, it must be a day (DD/MM/YYYY)
+      - If the second number > 12, it must be a day (MM/DD/YYYY)
+      - If both numbers are <= 12 (ambiguous), defaults to MM/DD/YYYY
     """
     s = (date_str or "").strip()
     if not s:
@@ -43,9 +45,19 @@ def parse_date(date_str: str) -> date:
     if y < 1900 or y > 2100:
         raise DateParseError(f"Year out of range: {y}")
 
-    # BUG: assumes a=month, b=day always.
-    month = a
-    day = b
+    # Auto-detect format based on values
+    if a > 12 and b <= 12:
+        # First number > 12, must be DD/MM/YYYY (EU format)
+        day = a
+        month = b
+    elif b > 12 and a <= 12:
+        # Second number > 12, must be MM/DD/YYYY (US format)
+        month = a
+        day = b
+    else:
+        # Both <= 12 (ambiguous), default to MM/DD/YYYY (US format)
+        month = a
+        day = b
 
     try:
         return date(y, month, day)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -7,7 +7,21 @@ def test_parse_us_date_mmddyyyy():
 
 
 def test_parse_eu_date_ddmmyyyy():
-    # This test is expected to FAIL until the bug is fixed.
     d = parse_date("31/01/2026")
     assert d.year == 2026 and d.month == 1 and d.day == 31
+
+
+def test_parse_us_date_with_dash_separator():
+    d = parse_date("12-25-2025")
+    assert d.year == 2025 and d.month == 12 and d.day == 25
+
+
+def test_parse_eu_date_with_dash_separator():
+    d = parse_date("25-12-2025")
+    assert d.year == 2025 and d.month == 12 and d.day == 25
+
+
+def test_parse_ambiguous_date_defaults_to_us_format():
+    d = parse_date("01/02/2026")
+    assert d.year == 2026 and d.month == 1 and d.day == 2
 


### PR DESCRIPTION
## Summary

Fixes #1 - Date parsing bug affecting EU deployments (DD/MM/YYYY)

## Changes

- Modified `parse_date` function to auto-detect date format based on values:
  - If first number > 12, treat as DD/MM/YYYY (EU format)
  - If second number > 12, treat as MM/DD/YYYY (US format)
  - If ambiguous (both <= 12), default to MM/DD/YYYY (US format)
- Updated docstring to reflect the new behavior
- Added tests for both formats with / and - separators
- Added test for ambiguous date handling

## Acceptance Criteria

- [x] `parse_date("31/01/2026")` returns 2026-01-31
- [x] `parse_date("01/31/2026")` still returns 2026-01-31
- [x] Existing tests pass and we keep coverage for both formats
- [x] Update docstring/comments to reflect final behavior

## Link to Devin run

https://app.devin.ai/sessions/ebb847ba581c409e9ba6705f8fbc31f2

Requested by: Diane Sarkis (@dianesarkis1)