### PR TITLE
Add --dry-run flag to validate-config CLI command

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
-from utils.config import load_yaml_config
+from utils.config import ConfigError, load_yaml_config
 from utils.dates import parse_date
 
 
@@ -17,6 +17,11 @@ def main(argv: list[str] | None = None) -> int:
 
     p_cfg = sub.add_parser("validate-config", help="Load a YAML config and print normalized JSON")
     p_cfg.add_argument("path", type=str, help="Path to YAML config file")
+    p_cfg.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate config without printing full contents; print 'OK' on success or error on failure",
+    )
 
     args = parser.parse_args(argv)
 
@@ -26,6 +31,14 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.cmd == "validate-config":
+        if args.dry_run:
+            try:
+                load_yaml_config(Path(args.path))
+                print("OK")
+                return 0
+            except ConfigError as e:
+                print(f"Error: {e}")
+                return 1
         cfg = load_yaml_config(Path(args.path))
         print(json.dumps(cfg, indent=2, sort_keys=True))
         return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from cli import main
 
 
@@ -6,4 +8,31 @@ def test_cli_parse_date_smoke(capsys):
     assert rc == 0
     out = capsys.readouterr().out.strip()
     assert out == "2026-01-31"
+
+
+def test_cli_validate_config_dry_run_valid(capsys, tmp_path: Path):
+    cfg_file = tmp_path / "valid.yaml"
+    cfg_file.write_text("service_name: my-service\n", encoding="utf-8")
+    rc = main(["validate-config", str(cfg_file), "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out == "OK"
+
+
+def test_cli_validate_config_dry_run_missing_file(capsys, tmp_path: Path):
+    missing_file = tmp_path / "missing.yaml"
+    rc = main(["validate-config", str(missing_file), "--dry-run"])
+    assert rc == 1
+    out = capsys.readouterr().out.strip()
+    assert "Error:" in out
+    assert "Config not found" in out
+
+
+def test_cli_validate_config_dry_run_invalid_yaml(capsys, tmp_path: Path):
+    invalid_file = tmp_path / "invalid.yaml"
+    invalid_file.write_text(":\n  - invalid: yaml: content\n", encoding="utf-8")
+    rc = main(["validate-config", str(invalid_file), "--dry-run"])
+    assert rc == 1
+    out = capsys.readouterr().out.strip()
+    assert "Error:" in out
 


### PR DESCRIPTION
## Summary
Adds a `--dry-run` flag to the `validate-config` CLI command as requested in issue #3.

## Changes
- Added `--dry-run` flag to the validate-config subparser
- When `--dry-run` is set, the command prints `OK` on success (exit 0) or a short error message on failure (exit 1)
- Added tests for valid YAML, missing file, and invalid YAML cases

## Testing
All new tests pass locally:
- `test_cli_validate_config_dry_run_valid` - validates that valid YAML prints OK and exits 0
- `test_cli_validate_config_dry_run_missing_file` - validates missing file returns error and exits 1
- `test_cli_validate_config_dry_run_invalid_yaml` - validates invalid YAML returns error and exits 1

Closes #3

---
**Requested by:** Diane Sarkis (@dianesarkis1)
**Link to Devin run:** https://app.devin.ai/sessions/5e1e179d01b84c82b0e6e5d692ffda5e